### PR TITLE
Remove rogue HTML tag from a pox command in PA3

### DIFF
--- a/assignments/simple-controller/README.md
+++ b/assignments/simple-controller/README.md
@@ -319,7 +319,7 @@ fm.actions.append(of.ofp_action_output(port = 4))
 <span></span>
 
 ```bash
-$ pox.py log.level --DEBUG forwarding.l2_learning</span>
+$ pox.py log.level --DEBUG forwarding.l2_learning
 ```
 
 <span>Like before, we'll create xterms for each host and view the traffic in each. In the Mininet console, start up three xterms:</span>


### PR DESCRIPTION
Remove rogue HTML tag from a pox command
