### PR TITLE
Correct path of pyretic source code

### DIFF
--- a/assignments/kinetic-gardenwall/submit.py
+++ b/assignments/kinetic-gardenwall/submit.py
@@ -170,7 +170,7 @@ partFriendlyNames = [' Host Gardenwall']
 
 # source files to collect (just for our records)
 sourceFiles = ['%s/pyretic/pyretic/kinetic/examples/gardenwall.py' % os.environ[ 'HOME' ],
-               '%s/pox/pox/kinetic/misc/gardenwall.py' % os.environ[ 'HOME' ],
+               '%s/pox/pox/misc/gardenwall.py' % os.environ[ 'HOME' ],
                '%s/pyretic/pyretic/examples/gardenwall.py' % os.environ[ 'HOME' ]]
 
 


### PR DESCRIPTION
Corrected path of pyretic source code inside submit.py from ~/pox/pox/kinetic/misc/gardenwall.py to ~/pox/pox/misc/gardenwall.py
