### PR TITLE
Redirect openflowswitch.org to github

### DIFF
--- a/setup/mininet-setup.sh
+++ b/setup/mininet-setup.sh
@@ -19,5 +19,6 @@ sudo rm /usr/share/man/man1/mnexec.1*
 git clone git://github.com/mininet/mininet
 pushd mininet
 git checkout -b 2.1.0p2 2.1.0p2
+git config --global url."http://github.com/mininet".insteadOf git://openflowswitch.org
 ./util/install.sh -fn03
 popd


### PR DESCRIPTION
During installation of mininet, the openflow
git repository is cloned. The previous location
is not reachable anymore. Redirect to the github
mirror to avoid patching the installation script
of mininet.

Signed-off-by: Ralf Anton Beier <ralf_beier@me.com>